### PR TITLE
Fix pro user course access and module visibility

### DIFF
--- a/app/student/courses/[id]/page.jsx
+++ b/app/student/courses/[id]/page.jsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import courseService from "@/services/courseService";
 import purchaseService from "@/services/purchaseService";
+import { studentService } from "@/services/studentService";
 import { Play, Lock, CheckCircle2, ShoppingCart, ChevronRight, BookOpen, DollarSign, Star, Users, Clock, Award } from "lucide-react";
 
 export default function CourseDetailPage() {
@@ -17,17 +18,20 @@ export default function CourseDetailPage() {
   const [activeModuleId, setActiveModuleId] = useState(null);
   const [purchasing, setPurchasing] = useState(false);
   const [myAccess, setMyAccess] = useState([]);
+  const [isPro, setIsPro] = useState(false);
 
   const isParent = course?.type === "parent";
   const isModule = course?.type === "module";
 
   const hasFullAccess = useMemo(() => {
     if (!course) return false;
-    return myAccess.some((access) => 
-      access.courseId?._id === course._id || 
-      access.courseId?._id === course.parentCourse
+    if (isPro) return true;
+    return myAccess.some(
+      (access) =>
+        access.courseId?._id === course._id ||
+        access.courseId?._id === course.parentCourse
     );
-  }, [myAccess, course]);
+  }, [myAccess, course, isPro]);
 
   const lessons = useMemo(() => (isModule ? course?.lessons || [] : []), [course, isModule]);
 
@@ -46,12 +50,16 @@ export default function CourseDetailPage() {
     if (!id) return;
     try {
       setLoading(true);
-      const [courseData, accessData] = await Promise.all([
+      const [courseData, accessData, profileRes] = await Promise.all([
         courseService.getById(id),
         courseService.myAccess().catch(() => []),
+        studentService.getProfile().catch(() => null),
       ]);
       setCourse(courseData);
       setMyAccess(accessData || []);
+      const studentData = profileRes?.data || profileRes?.data?.data || profileRes?.data; // handle different shapes defensively
+      const plan = (studentData?.plan || studentData?.data?.plan || "free").toLowerCase();
+      setIsPro(plan === "pro");
       if (courseData?.lessons?.length) setActiveLessonId(courseData.lessons[0]._id);
       if (courseData?.modules?.length) setActiveModuleId(courseData.modules[0]._id);
     } catch (e) {
@@ -251,7 +259,8 @@ export default function CourseDetailPage() {
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {course.modules && course.modules.length > 0 ? (
               course.modules.map((module) => {
-                const hasModuleAccess = myAccess.some((access) => access.courseId?._id === module._id);
+                const isFreeModule = Number(module?.pricing?.individualPrice || 0) === 0;
+                const hasModuleAccess = isPro || isFreeModule || myAccess.some((access) => access.courseId?._id === module._id);
                 return (
                   <div
                     key={module._id}

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -39,3 +39,24 @@ export function authorize(roles = []) {
     next();
   };
 }
+
+// ✅ Optional authentication: attach req.user if token is valid; otherwise continue
+export async function maybeAuthenticate(req, _res, next) {
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      return next();
+    }
+
+    const token = authHeader.split(" ")[1];
+    const decoded = jwt.verify(token, env.jwtSecret);
+    const user = await UserModel.findById(decoded.id).select("-passwordHash");
+    if (user) {
+      req.user = { id: user._id.toString(), role: user.role };
+    }
+    return next();
+  } catch (_err) {
+    // Ignore invalid token and proceed as anonymous
+    return next();
+  }
+}

--- a/backend/src/routes/courses.js
+++ b/backend/src/routes/courses.js
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { authenticate } from "../middleware/auth.js";
+import { authenticate, maybeAuthenticate } from "../middleware/auth.js";
 import { authorize } from "../middleware/auth.js";
 import { courseController } from "../controllers/courseController.js";
 
@@ -73,6 +73,7 @@ router.delete(
 );
 
 // ✅ This should be LAST to avoid intercepting other routes
-router.get("/:id", courseController.getCourseById);
+// Allow optional auth so pro users can get full lessons on module
+router.get("/:id", maybeAuthenticate, courseController.getCourseById);
 
 export default router;


### PR DESCRIPTION
Correct module access display for pro and free users on the course detail page.

Previously, pro users were incorrectly shown "Buy Module" for all modules. This change ensures pro users see "Start Learning" for all modules, while free users see "Start Learning" for free modules and "Buy Module" for paid ones. The backend `GET /api/courses/:id` route was updated with optional authentication to allow pro users to fetch full lesson details.

---
<a href="https://cursor.com/background-agent?bcId=bc-4d8948cd-7866-4951-94ee-128c2d4bcf0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4d8948cd-7866-4951-94ee-128c2d4bcf0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

